### PR TITLE
Drop unused commitlint.config.js

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = {extends: ['@commitlint/config-conventional']}


### PR DESCRIPTION
This file isn't currently being utilized, so let's remove it. There's no need to keep copying it into our modules, if we need it in the future we can mass-update repositories to include it. The migration script will be dropping this file from module repositories as they are migrated.