### PR TITLE
NOTICE no longer includes module name reference

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,7 @@
-lcaf-skeleton-terraform
 Copyright 2024 NTT DATA, Inc.
 
 Software, source files, and snippets are licensed under the Apache 2.0 license.
 
-All other content (eg documentation), unless otherwise specified, is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0) License (<https://creativecommons.org/licenses/by-nc-nd/4.0/>).
+All other content (e.g. documentation), unless otherwise specified, is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0) License (<https://creativecommons.org/licenses/by-nc-nd/4.0/>).
 
 If you discover a file that does not specify specify its license that should be licensed, please contact the repository owners as soon as possible to resolve the issue.


### PR DESCRIPTION
Removes the module name from the NOTICE file.

This isn't necessary for compliance with the license, the NOTICE file applies to the entire repository and doesn't need to have a reference to the repository name. Additionally, this removes a dynamic value from all our TF modules going forward... one less thing to consider in a PR review.

The migration script will apply this fix to all modules that are migrated to this new organization.