### PR TITLE
Update .tool-versions with latest dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,9 +1,9 @@
 conftest 0.44.1
-golang 1.21.7
-golangci-lint 1.55.2
+golang 1.21.11
+golangci-lint 1.59.1
 pre-commit 3.3.3
 regula 3.2.1 # https://github.com/launchbynttdata/asdf-regula
 terraform 1.5.5
 terraform-docs 0.16.0
-terragrunt 0.39.2
-tflint 0.48.0
+terragrunt 0.51.6
+tflint 0.51.2


### PR DESCRIPTION
Includes update to packages in .tool-versions as seen here: https://github.com/launchbynttdata/launch-build-agent-base/pull/8.

As mentioned in the other PR, individual repositories that reference older versions of dependencies will need their .tool-versions files updated accordingly. This is just an update to the skeleton so that modules going forward will reflect the latest.