### PR TITLE
fix: improve dependabot behaviors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,30 @@
 version: 2
+
+multi-ecosystem-groups:
+  module:
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+  workflows:
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "workflows"
+    patterns: ["*"]
+    labels: ["dependencies"]
+
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "module"
+    patterns: ["*"]
+    labels: ["dependencies"]
+
   - package-ecosystem: "terraform"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "module"
+    patterns: ["*"]
+    labels: ["dependencies"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,27 +4,22 @@ multi-ecosystem-groups:
   module:
     schedule:
       interval: "weekly"
-    labels: ["dependencies"]
   workflows:
     schedule:
       interval: "weekly"
-    labels: ["dependencies"]
 
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     multi-ecosystem-group: "workflows"
     patterns: ["*"]
-    labels: ["dependencies"]
 
   - package-ecosystem: "gomod"
     directory: "/"
     multi-ecosystem-group: "module"
     patterns: ["*"]
-    labels: ["dependencies"]
 
   - package-ecosystem: "terraform"
     directory: "/"
     multi-ecosystem-group: "module"
     patterns: ["*"]
-    labels: ["dependencies"]

--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -11,5 +11,5 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@0.14.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@0.14.2
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/pull-request-terraform-check-aws.yml
+++ b/.github/workflows/pull-request-terraform-check-aws.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-aws.yml@0.14.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-aws.yml@0.14.2
     with:
       assume_role_arn: ${{ vars.TERRAFORM_CHECK_AWS_ASSUME_ROLE_ARN }}
       region: ${{ vars.TERRAFORM_CHECK_AWS_REGION }}

--- a/.github/workflows/pull-request-terraform-check-azure.yml
+++ b/.github/workflows/pull-request-terraform-check-azure.yml
@@ -17,5 +17,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@0.14.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@0.14.2
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,5 +14,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@0.14.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@0.14.2
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
> [!CAUTION]
> This pull request depends on the following PR being merged and released: https://github.com/launchbynttdata/launch-workflows/pull/71

Two major changes to the way we're handling Dependabot:

1. Dependabot will now group PRs with similar changes together. This means that instead of getting one PR for every single dependency update, we can expect one for workflow updates and one for module updates, like so:

<img width="826" height="199" alt="image" src="https://github.com/user-attachments/assets/0f8f54e1-f797-4084-9c53-53a1e645828e" />

2. Bumps workflows to consume the new version of launch-workflows that includes logic to strip labels that Dependabot applies not matching `dependencies`, as shown below:

<img width="618" height="117" alt="image" src="https://github.com/user-attachments/assets/a1333828-6f6e-44c1-be7b-6838649b1686" />

This will prevent Dependabot from erroneously bumping a minor or major version and constrain it to bumping patch versions only.