### PR TITLE
fix(dependabot): forbid major version updates of Terraform dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,12 @@ updates:
     directory: "/"
     multi-ecosystem-group: "module"
     patterns: ["*"]
+    ignore:
+      - dependency-name: "hashicorp/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "microsoft/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "azure/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "integrations/*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Should keep Dependabot from recommending breaking changes.